### PR TITLE
Chore/upgrade workspace 20260525

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -4,7 +4,7 @@
     <!-- build info-->
     <!-- ============================================================================ -->
     <!-- Set the target frameworks for all projects -->
-    <TargetFrameworks>net8.0;net9.0</TargetFrameworks>
+    <TargetFrameworks>net10.0</TargetFrameworks>
     <!-- Set the configuration to Debug by default -->
     <Configuration Condition=" '$(Configuration)' == '' ">Debug</Configuration>
     <!-- Enable nullable reference types -->
@@ -20,7 +20,7 @@
     <EnablePackageValidation>true</EnablePackageValidation>
     <PackageLicenseExpression>MIT</PackageLicenseExpression>
     <PackageTags>syrx;data access;orm;micro-orm</PackageTags>
-    <PackageReleaseNotes>Last release on .NET8.0 exclusively. Next release will include .NET9.0.</PackageReleaseNotes>
+    <PackageReleaseNotes>Release aligned to .NET 10 exclusively.</PackageReleaseNotes>
     <!-- ============================================================================ -->
     <!-- organization info -->
     <!-- ============================================================================ -->

--- a/src/Syrx.Commanders.Databases.Connectors.Cockroach.Extensions/Syrx.Commanders.Databases.Connectors.Cockroach.Extensions.csproj
+++ b/src/Syrx.Commanders.Databases.Connectors.Cockroach.Extensions/Syrx.Commanders.Databases.Connectors.Cockroach.Extensions.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/src/Syrx.Commanders.Databases.Connectors.Cockroach/Syrx.Commanders.Databases.Connectors.Cockroach.csproj
+++ b/src/Syrx.Commanders.Databases.Connectors.Cockroach/Syrx.Commanders.Databases.Connectors.Cockroach.csproj
@@ -5,7 +5,7 @@
 	</PropertyGroup>
 
 	<ItemGroup>
-		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
+		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
 		<PackageReference Include="Npgsql" Version="9.0.3" />
 	</ItemGroup>
 

--- a/src/Syrx.Commanders.Databases.Connectors.Cockroach/Syrx.Commanders.Databases.Connectors.Cockroach.csproj
+++ b/src/Syrx.Commanders.Databases.Connectors.Cockroach/Syrx.Commanders.Databases.Connectors.Cockroach.csproj
@@ -6,7 +6,7 @@
 
 	<ItemGroup>
 		<PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
-		<PackageReference Include="Npgsql" Version="9.0.3" />
+		<PackageReference Include="Npgsql" Version="10.0.3" />
 	</ItemGroup>
 
 	<ItemGroup>

--- a/tests/integration/Syrx.Cockroach.Tests.Integration/Syrx.Cockroach.Tests.Integration.csproj
+++ b/tests/integration/Syrx.Cockroach.Tests.Integration/Syrx.Cockroach.Tests.Integration.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 
@@ -10,13 +10,13 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="9.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
-    <PackageReference Include="Syrx.Validation" Version="2.0.0" />
+    <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
+    <PackageReference Include="Syrx.Validation" Version="3.0.0" />
     <PackageReference Include="Testcontainers.CockroachDb" Version="4.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">

--- a/tests/integration/Syrx.Cockroach.Tests.Integration/Syrx.Cockroach.Tests.Integration.csproj
+++ b/tests/integration/Syrx.Cockroach.Tests.Integration/Syrx.Cockroach.Tests.Integration.csproj
@@ -19,7 +19,7 @@
     <PackageReference Include="Syrx.Validation" Version="3.0.0" />
     <PackageReference Include="Testcontainers.CockroachDb" Version="4.7.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/unit/Syrx.Commanders.Databases.Connectors.Cockroach.Extensions.Tests.Unit/Syrx.Commanders.Databases.Connectors.Cockroach.Extensions.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Connectors.Cockroach.Extensions.Tests.Unit/Syrx.Commanders.Databases.Connectors.Cockroach.Extensions.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 
@@ -10,12 +10,12 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
     <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/unit/Syrx.Commanders.Databases.Connectors.Cockroach.Extensions.Tests.Unit/Syrx.Commanders.Databases.Connectors.Cockroach.Extensions.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Connectors.Cockroach.Extensions.Tests.Unit/Syrx.Commanders.Databases.Connectors.Cockroach.Extensions.Tests.Unit.csproj
@@ -14,10 +14,10 @@
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="9.0.9" />
+    <PackageReference Include="Microsoft.Extensions.DependencyInjection" Version="10.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>

--- a/tests/unit/Syrx.Commanders.Databases.Connectors.Cockroach.Tests.Unit/Syrx.Commanders.Databases.Connectors.Cockroach.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Connectors.Cockroach.Tests.Unit/Syrx.Commanders.Databases.Connectors.Cockroach.Tests.Unit.csproj
@@ -1,7 +1,7 @@
 <Project Sdk="Microsoft.NET.Sdk">
 
   <PropertyGroup>
-    <TargetFramework>net8.0</TargetFramework>
+    <TargetFramework>net10.0</TargetFramework>
     <ImplicitUsings>enable</ImplicitUsings>
     <Nullable>disable</Nullable>
 
@@ -10,11 +10,11 @@
   </PropertyGroup>
 
   <ItemGroup>
-    <PackageReference Include="coverlet.collector" Version="6.0.4">
+    <PackageReference Include="coverlet.collector" Version="10.0.1">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>
-    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="17.14.1" />
+    <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
       <PrivateAssets>all</PrivateAssets>

--- a/tests/unit/Syrx.Commanders.Databases.Connectors.Cockroach.Tests.Unit/Syrx.Commanders.Databases.Connectors.Cockroach.Tests.Unit.csproj
+++ b/tests/unit/Syrx.Commanders.Databases.Connectors.Cockroach.Tests.Unit/Syrx.Commanders.Databases.Connectors.Cockroach.Tests.Unit.csproj
@@ -16,7 +16,7 @@
     </PackageReference>
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
-    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.4">
+    <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers; buildtransitive</IncludeAssets>
     </PackageReference>


### PR DESCRIPTION
This pull request updates the project to target .NET 10 exclusively and upgrades related dependencies and submodules accordingly. The main focus is on modernizing the codebase and ensuring compatibility with the latest .NET ecosystem.

**Target framework and compatibility updates:**

* Updated all projects to target only `net10.0`, dropping support for previous .NET versions. (`Directory.Build.props`, `Syrx.Cockroach.Tests.Integration.csproj`, `Syrx.Commanders.Databases.Connectors.Cockroach.Extensions.Tests.Unit.csproj`, `Syrx.Commanders.Databases.Connectors.Cockroach.Tests.Unit.csproj`) [[1]](diffhunk://#diff-9da24614831c308827a1ae533ffea392c97638c261dd42bd0f5226baa136d16eL7-R7) [[2]](diffhunk://#diff-6cc3714e3f5d28fb151e0d67f450cde538d3220ba3cf42f0101b13a301548e8eL4-R4) [[3]](diffhunk://#diff-98721feab405b6be15f2488cb9a7d54adf7ae86dda1d8ed106a2ccab6012bcd9L4-R4) [[4]](diffhunk://#diff-80eaf71a0060a745cf1623fec0a87ff805fbf7252eaf218071c5b7e60f14c42aL4-R4)

**Dependency upgrades:**

* Upgraded major dependencies to their .NET 10-compatible versions, including `Microsoft.Extensions.DependencyInjection`, `Npgsql`, `Microsoft.Extensions.Logging.Console`, `Microsoft.NET.Test.Sdk`, `coverlet.collector`, and `Syrx.Validation`. (`Syrx.Commanders.Databases.Connectors.Cockroach.Extensions.csproj`, `Syrx.Commanders.Databases.Connectors.Cockroach.csproj`, `Syrx.Cockroach.Tests.Integration.csproj`, `Syrx.Commanders.Databases.Connectors.Cockroach.Extensions.Tests.Unit.csproj`, `Syrx.Commanders.Databases.Connectors.Cockroach.Tests.Unit.csproj`) [[1]](diffhunk://#diff-a6e9489fc868eb32b6ca2b002d99fb0ec763c1465cccab2fc3a6828dc4e9414eL8-R8) [[2]](diffhunk://#diff-54318f7547f87c0ab3e111f6cb3111a5781eeeab68d94e54fdf993035d09b73eL8-R9) [[3]](diffhunk://#diff-6cc3714e3f5d28fb151e0d67f450cde538d3220ba3cf42f0101b13a301548e8eL13-R22) [[4]](diffhunk://#diff-98721feab405b6be15f2488cb9a7d54adf7ae86dda1d8ed106a2ccab6012bcd9L13-R20) [[5]](diffhunk://#diff-80eaf71a0060a745cf1623fec0a87ff805fbf7252eaf218071c5b7e60f14c42aL13-R19)

**Submodule update:**

* Updated the `Syrx.Commanders.Databases` submodule to the latest commit, likely to align with .NET 10 and dependency changes. (`.submodules/Syrx.Commanders.Databases`)

**Release notes and documentation:**

* Updated release notes to indicate that the package now targets .NET 10 exclusively. (`Directory.Build.props`)