### PR TITLE
Chore/upgrade workspace 20260525

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,6 +16,8 @@ on:
 env:
   NuGetDirectory: ${{ github.workspace }}/src/*/bin/Release/
 
+permissions: {}
+
 defaults:
   run:
     shell: pwsh
@@ -23,6 +25,8 @@ defaults:
 jobs:
   create_nuget:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     strategy:
       matrix:
         dotnet-version: [ '10.0.x' ]
@@ -57,6 +61,8 @@ jobs:
   validate_nuget:
     runs-on: ubuntu-latest
     needs: [ create_nuget ]
+    permissions:
+      contents: read
     steps:
       # Install the .NET SDK indicated in the global.json file
       - name: Setup .NET
@@ -70,6 +76,8 @@ jobs:
 
   run_test:
     runs-on: ubuntu-latest
+    permissions:
+      contents: read
     steps:
     - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with: 
@@ -90,6 +98,8 @@ jobs:
     if: github.event_name == 'release'
     runs-on: ubuntu-latest
     needs: [ validate_nuget, run_test ]
+    permissions:
+      contents: read
     steps:
       # Download the NuGet package created in the previous job
       - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -25,10 +25,10 @@ jobs:
     runs-on: ubuntu-latest
     strategy:
       matrix:
-        dotnet-version: [ '8.0.x' ]
+        dotnet-version: [ '10.0.x' ]
         
     steps:    
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       name: Setup dotnet ${{ matrix.dotnet-version }}
       with:
         submodules: recursive
@@ -36,7 +36,7 @@ jobs:
     - name: Initialize submodules
       run: git submodule update --init --recursive
         
-    - uses: actions/setup-dotnet@v5
+    - uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
       with:
           dotnet-version: ${{ matrix.dotnet-version }}
       # You can test your matrix by printing the current dotnet version
@@ -47,7 +47,7 @@ jobs:
     - run: dotnet build --configuration Release
 
     # Publish the NuGet package as an artifact, so they can be used in the following jobs
-    - uses: actions/upload-artifact@v4
+    - uses: actions/upload-artifact@bbbca2ddaa5d8feaa63e36b76fdaad77386f024f # v7.0.0
       with:
         name: nuget
         if-no-files-found: error
@@ -60,10 +60,10 @@ jobs:
     steps:
       # Install the .NET SDK indicated in the global.json file
       - name: Setup .NET
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
 
       # Download the NuGet package created in the previous job
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nuget
           path: ${{ env.NuGetDirectory }}
@@ -71,13 +71,15 @@ jobs:
   run_test:
     runs-on: ubuntu-latest
     steps:
-    - uses: actions/checkout@v5
+    - uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6.0.2
       with: 
         submodules: recursive
-    - name: Setup .NET ${{ matrix.dotnet-version }}
+    - name: Setup .NET
       
 
-      uses: actions/setup-dotnet@v5
+      uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
+      with:
+        dotnet-version: '10.0.x'
     - name: Run tests
       run: dotnet test --configuration Release
 
@@ -90,14 +92,14 @@ jobs:
     needs: [ validate_nuget, run_test ]
     steps:
       # Download the NuGet package created in the previous job
-      - uses: actions/download-artifact@v5
+      - uses: actions/download-artifact@3e5f45b2cfb9172054b4087a40e8e0b5a5461e7c # v8.0.1
         with:
           name: nuget
           path: ${{ env.NuGetDirectory }}
 
       # Install the .NET SDK indicated in the global.json file
       - name: Setup .NET Core
-        uses: actions/setup-dotnet@v5
+        uses: actions/setup-dotnet@c2fa09f4bde5ebb9d1777cf28262a3eb3db3ced7 # v5.2.0
 
       # Publish all NuGet packages to NuGet.org
       # Use --skip-duplicate to prevent errors if a package with the same version already exists.


### PR DESCRIPTION
This pull request updates the GitHub Actions workflow in `.github/workflows/publish.yml` to improve security and keep dependencies up to date. The main changes include pinning action versions to specific commit SHAs, updating the .NET version used in the build matrix, and explicitly setting permissions for each job.

**Security and Dependency Updates:**

* All GitHub Actions are now pinned to specific commit SHAs for improved security and reproducibility, replacing version tags like `@v5` with SHA references [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R19-R43) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7L50-R54) [[3]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R64-R90) [[4]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R101-R112).
* The `.NET` version used in the build matrix and test setup has been updated from `8.0.x` to `10.0.x`.

**Workflow Permissions:**

* Explicitly set `contents: read` permissions for all jobs, and added a top-level empty `permissions` block to restrict default permissions [[1]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R19-R43) [[2]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R64-R90) [[3]](diffhunk://#diff-551d1fcf87f78cc3bc18a7b332a4dc5d8773a512062df881c5aba28a6f5c48d7R101-R112).

These changes make the workflow more secure and future-proof by ensuring only the intended permissions are granted and dependencies are reliably versioned.