### PR TITLE
deps: upgrade cockroach residual testcontainers and reproducible builds

### DIFF
--- a/Directory.Build.props
+++ b/Directory.Build.props
@@ -32,7 +32,7 @@
     <!-- ============================================================================ -->
   </PropertyGroup>
   <ItemGroup>
-    <PackageReference Include="DotNet.ReproducibleBuilds" Version="1.2.25">
+    <PackageReference Include="DotNet.ReproducibleBuilds" Version="2.0.2">
       <PrivateAssets>all</PrivateAssets>
       <IncludeAssets>runtime; build; native; contentfiles; analyzers</IncludeAssets>
     </PackageReference>

--- a/tests/integration/Syrx.Cockroach.Tests.Integration/CockroachFixture.cs
+++ b/tests/integration/Syrx.Cockroach.Tests.Integration/CockroachFixture.cs
@@ -7,8 +7,7 @@ namespace Syrx.Cockroach.Tests.Integration
 
         public CockroachFixture()
         {
-            _container = new CockroachDbBuilder()
-                .WithImage("cockroachdb/cockroach:v23.1.11")
+            _container = new CockroachDbBuilder("cockroachdb/cockroach:v23.1.11")
                 .WithUsername("root")
                 .WithDatabase("defaultdb")
                 .Build();

--- a/tests/integration/Syrx.Cockroach.Tests.Integration/Syrx.Cockroach.Tests.Integration.csproj
+++ b/tests/integration/Syrx.Cockroach.Tests.Integration/Syrx.Cockroach.Tests.Integration.csproj
@@ -17,7 +17,7 @@
     <PackageReference Include="Microsoft.Extensions.Logging.Console" Version="10.0.8" />
     <PackageReference Include="Microsoft.NET.Test.Sdk" Version="18.6.0" />
     <PackageReference Include="Syrx.Validation" Version="3.0.0" />
-    <PackageReference Include="Testcontainers.CockroachDb" Version="4.7.0" />
+    <PackageReference Include="Testcontainers.CockroachDb" Version="4.12.0" />
     <PackageReference Include="xunit" Version="2.9.3" />
     <PackageReference Include="xunit.runner.visualstudio" Version="3.1.5">
       <PrivateAssets>all</PrivateAssets>


### PR DESCRIPTION
This pull request updates dependencies and makes a minor code change to improve compatibility with the latest versions. The most important changes are grouped below:

Dependency updates:

* Upgraded `DotNet.ReproducibleBuilds` package from version 1.2.25 to 2.0.2 in `Directory.Build.props` to ensure reproducible builds use the latest features and fixes.
* Updated `Testcontainers.CockroachDb` package from version 4.7.0 to 4.12.0 in the test project to take advantage of improvements and bug fixes.

Code changes for compatibility:

* Changed the initialization of `CockroachDbBuilder` in `CockroachFixture` to use the constructor that accepts the image name, aligning with the updated `Testcontainers.CockroachDb` API.